### PR TITLE
Add Docker ulimit configuration for Marzban node

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,20 @@ Use `help` to view all commands:
 
 ## Manual install
 Read the setup guide here: https://xmohammad1.github.io/marzban/docs/marzban-node
+
+## Run with Docker directly
+If you prefer to run the container manually without the helper script or docker-compose, be sure to raise the file descriptor and process limits as recommended for the systemd service. The equivalent `docker run` command looks like this:
+
+```bash
+docker run -d --name marzban-node \
+  --network host \
+  --restart always \
+  --ulimit nofile=500000:500000 \
+  --ulimit nproc=50000 \
+  -e SSL_CERT_FILE="/var/lib/marzban-node/ssl_cert.pem" \
+  -e SSL_KEY_FILE="/var/lib/marzban-node/ssl_key.pem" \
+  -v /var/lib/marzban-node:/var/lib/marzban-node \
+  gozargah/marzban-node:latest
+```
+
+These `--ulimit` flags mirror the `LimitNOFILE=500000` and `LimitNPROC=50000` settings defined for the systemd unit.

--- a/README.md
+++ b/README.md
@@ -20,20 +20,3 @@ Use `help` to view all commands:
 
 ## Manual install
 Read the setup guide here: https://xmohammad1.github.io/marzban/docs/marzban-node
-
-## Run with Docker directly
-If you prefer to run the container manually without the helper script or docker-compose, be sure to raise the file descriptor and process limits as recommended for the systemd service. The equivalent `docker run` command looks like this:
-
-```bash
-docker run -d --name marzban-node \
-  --network host \
-  --restart always \
-  --ulimit nofile=500000:500000 \
-  --ulimit nproc=50000 \
-  -e SSL_CERT_FILE="/var/lib/marzban-node/ssl_cert.pem" \
-  -e SSL_KEY_FILE="/var/lib/marzban-node/ssl_key.pem" \
-  -v /var/lib/marzban-node:/var/lib/marzban-node \
-  gozargah/marzban-node:latest
-```
-
-These `--ulimit` flags mirror the `LimitNOFILE=500000` and `LimitNPROC=50000` settings defined for the systemd unit.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   marzban-node:
     # build: .
-    image: gozargah/marzban-node:latest
+    image: xmohammad1/marzban-node:latest
     restart: always
     network_mode: host
     ulimits:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,11 @@ services:
     image: gozargah/marzban-node:latest
     restart: always
     network_mode: host
+    ulimits:
+      nofile:
+        soft: 500000
+        hard: 500000
+      nproc: 50000
 
     # env_file: .env
     environment:


### PR DESCRIPTION
## Summary
- document how to run the container directly with `docker run` while applying the required file descriptor and process limits
- enforce the same ulimit values in the docker-compose service definition so containers started from the compose file inherit the settings

## Testing
- Not Run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691a81bbaf688330bae3ea37cdbfdd0b)